### PR TITLE
Add script for resume channel

### DIFF
--- a/scripts/resume.coffee
+++ b/scripts/resume.coffee
@@ -1,0 +1,4 @@
+module.exports = (robot) ->
+  names = ['Dana', 'Freia', 'Jhishan', 'Kyle', 'Brenton', 'Terri', 'Abhi', 'Drew']
+  robot.hear /Resume queen, who is next?/i, (res) ->
+    res.send res.random names


### PR DESCRIPTION
@AbhiAgarwal my first time doing this! let me know if I did the whole thing wrong lol

When someone types `Resume queen, who is next?` the script should randomly select someone in the channel to have them send their resume :smile: (This is really only for #resumes, don't know if there's a way to specify a script for a specific channel)
